### PR TITLE
Utilities to convert Zig targets to Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Zig version
         run: zig version
 
-      - name: Build
-        run: zig build --summary all
+      - name: Build & Test
+        run: zig build test --summary all
 
       - name: Run integration tests
         run: |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ module.addLibraryPath(crate_lib_path.dirname());
 module.linkSystemLibrary("crate", .{});
 ```
 
+## Target triples
+
+This package also provides [some utilities](src/rust.zig) to convert target triples between Zig and Rust.
+Currently, only tier 1 targets are somewhat tested. If you notice inconsistencies, please file a bug report.
+
 ## Windows
 
 ![Hydra meme with Windows as the weird head!](./images/windows%20is%20the%20weird%20one.jpeg)

--- a/build.zig
+++ b/build.zig
@@ -124,7 +124,7 @@ pub fn addCargoBuildWithUserOptions(b: *std.Build, config: CargoConfig, args: an
         var target = @import("builtin").target;
         target.abi = .gnu;
         build_crab.addArg("--target");
-        build_crab.addArg(@This().Target.fromZig(target));
+        build_crab.addArg(@This().Target.fromZig(target) catch @panic("unable to convert target triple to Rust"));
     }
 
     build_crab.addArgs(config.cargo_args);

--- a/build.zig
+++ b/build.zig
@@ -123,8 +123,9 @@ pub fn addCargoBuildWithUserOptions(b: *std.Build, config: CargoConfig, args: an
     } else if (@import("builtin").target.os.tag == .windows) {
         var target = @import("builtin").target;
         target.abi = .gnu;
+        const rust_target = @This().Target.fromZig(target) catch @panic("unable to convert target triple to Rust");
         build_crab.addArg("--target");
-        build_crab.addArg(@This().Target.fromZig(target) catch @panic("unable to convert target triple to Rust"));
+        build_crab.addArg(b.fmt("{}", .{rust_target}));
     }
 
     build_crab.addArgs(config.cargo_args);

--- a/build.zig
+++ b/build.zig
@@ -1,9 +1,16 @@
 const std = @import("std");
 
+pub usingnamespace @import("src/root.zig");
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
-
     const optimize = b.standardOptimizeOption(.{});
+
+    _ = b.addModule("build.crab", .{
+        .root_source_file = .{ .path = "src/root.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
 
     const exe = b.addExecutable(.{
         .name = "build_crab",
@@ -44,6 +51,17 @@ pub fn build(b: *std.Build) void {
 
     const run_strip_symbols_step = b.step("strip", "Run the app");
     run_strip_symbols_step.dependOn(&run_strip_symbols.step);
+
+    const lib_unit_tests = b.addTest(.{
+        .root_source_file = b.path("src/root.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const run_lib_unit_tests = b.addRunArtifact(lib_unit_tests);
+
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_lib_unit_tests.step);
 }
 
 const CargoConfig = struct {

--- a/build.zig
+++ b/build.zig
@@ -80,7 +80,7 @@ const CargoConfig = struct {
     cargo_args: []const []const u8 = &.{},
 
     /// Target architecture.
-    /// If null, build.zig will use x86_64-pc-windows-gnu on Windows.
+    /// If null, build.zig will use gnu ABI on Windows.
     target: ?[]const u8 = null,
 };
 
@@ -121,8 +121,10 @@ pub fn addCargoBuildWithUserOptions(b: *std.Build, config: CargoConfig, args: an
         build_crab.addArg("--target");
         build_crab.addArg(target);
     } else if (@import("builtin").target.os.tag == .windows) {
+        var target = @import("builtin").target;
+        target.abi = .gnu;
         build_crab.addArg("--target");
-        build_crab.addArg("x86_64-pc-windows-gnu");
+        build_crab.addArg(@This().Target.fromZig(target));
     }
 
     build_crab.addArgs(config.cargo_args);

--- a/build.zig
+++ b/build.zig
@@ -172,3 +172,19 @@ pub fn addStripSymbolsWithUserOptions(b: *std.Build, config: StripSymbolsConfig,
 
     return out_file;
 }
+
+/// A combination of `addCargoBuild` and `addStripSymbols` that strips `___chkstk_ms` on Windows.
+pub fn addRustStaticlib(b: *std.Build, config: CargoConfig) std.Build.LazyPath {
+    var crate_lib_path = addCargoBuild(b, config);
+
+    if (@import("builtin").target.os.tag == .windows) {
+        crate_lib_path = addStripSymbols(b, .{
+            .name = config.name,
+            .archive = crate_lib_path,
+            .symbols = &.{
+                "___chkstk_ms",
+            },
+        });
+    }
+    return crate_lib_path;
+}

--- a/example/build.zig
+++ b/example/build.zig
@@ -12,7 +12,7 @@ pub fn build(b: *std.Build) void {
 
     const build_crab = @import("build.crab");
 
-    var crate_lib_path = build_crab.addCargoBuild(b, .{
+    var crate_lib_path = build_crab.addRustStaticlib(b, .{
         .name = "libcrate.a",
         .manifest_path = b.path("rust/Cargo.toml"),
         .cargo_args = &.{
@@ -20,16 +20,6 @@ pub fn build(b: *std.Build) void {
             "--quiet",
         },
     });
-
-    if (@import("builtin").target.os.tag == .windows) {
-        crate_lib_path = build_crab.addStripSymbols(b, .{
-            .name = "libcrate.a",
-            .archive = crate_lib_path,
-            .symbols = &.{
-                "___chkstk_ms",
-            },
-        });
-    }
 
     lib_unit_tests.linkLibCpp();
     lib_unit_tests.addLibraryPath(crate_lib_path.dirname());

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,0 +1,7 @@
+const std = @import("std");
+
+pub usingnamespace @import("rust.zig");
+
+test {
+    std.testing.refAllDecls(@This());
+}

--- a/src/rust.zig
+++ b/src/rust.zig
@@ -1,0 +1,361 @@
+const std = @import("std");
+
+pub const Target = struct {
+    arch: Arch,
+    vendor: Vendor,
+    os: Os,
+    env: Env,
+
+    pub fn fromZig(target: std.Target) error{Unsupported}!Target {
+        return Target{
+            .arch = try Arch.fromZig(target.cpu.arch),
+            .vendor = try Vendor.fromZig(target),
+            .os = try Os.fromZig(target.os),
+            .env = try Env.fromZig(target.abi),
+        };
+    }
+
+    pub fn fromQuery(query: std.Target.Query) !Target {
+        const target = try std.zig.system.resolveTargetQuery(query);
+        return fromZig(target);
+    }
+
+    pub fn fromArchOsAbi(arch_os_abi: []const u8) !Target {
+        const query = try std.Target.Query.parse(.{
+            .arch_os_abi = arch_os_abi,
+        });
+        return fromQuery(query);
+    }
+
+    pub fn format(self: Target, comptime fmt_spec: []const u8, options: std.fmt.FormatOptions, writer: anytype) !void {
+        _ = fmt_spec;
+        _ = options;
+        if (self.arch == .wasm32 and self.os == .wasi) {
+            try writer.print("{s}-{s}", .{ @tagName(self.arch), @tagName(self.os) });
+        } else if (self.env == .none) {
+            try writer.print("{s}-{s}-{s}", .{ @tagName(self.arch), @tagName(self.vendor), @tagName(self.os) });
+        } else {
+            try writer.print("{s}-{s}-{s}-{s}", .{ @tagName(self.arch), @tagName(self.vendor), @tagName(self.os), @tagName(self.env) });
+        }
+    }
+};
+
+pub const Arch = enum {
+    aarch64,
+    aarch64_be,
+    arm,
+    arm64_32,
+    armeb,
+    armebv7r,
+    armv4t,
+    armv5te,
+    armv6,
+    armv6k,
+    arm7,
+    arm7a,
+    arm7k,
+    arm7r,
+    arm7s,
+    asmjs,
+    avr,
+    bpfeb,
+    bpfel,
+    csky,
+    hexagon,
+    i386,
+    i586,
+    i686,
+    loongarch64,
+    m68k,
+    mips,
+    mips64,
+    mips64el,
+    mipsel,
+    mipsisa32r6,
+    mipsisa32r6el,
+    mipsisa64r6,
+    mipsisa64r6el,
+    msp430,
+    nvptx64,
+    powerpc,
+    powerpc64,
+    powerpc64le,
+    riscv32gc,
+    riscv32i,
+    riscv32im,
+    riscv32imac,
+    riscv32imc,
+    riscv64,
+    riscv64gc,
+    riscv64imac,
+    s390x,
+    sparc,
+    sparc64,
+    sparcv9,
+    thumbv4t,
+    thumbv5te,
+    thumbv6m,
+    thumbv7a,
+    thumbv7em,
+    thumbv7m,
+    thumbv7neon,
+    thumbv8m_base,
+    thumbv8m_main,
+    wasm32,
+    wasm64,
+    x86_64,
+    x86_64h,
+
+    pub fn fromZig(arch: std.Target.Cpu.Arch) error{Unsupported}!Arch {
+        return switch (arch) {
+            .aarch64 => .aarch64,
+            .aarch64_32 => error.Unsupported,
+            .aarch64_be => .aarch64_be,
+            .arm => .arm,
+            .armeb => .armeb,
+            .avr => .avr,
+            .bpfeb => .bpfeb,
+            .bpfel => .bpfel,
+            .csky => .csky,
+            .hexagon => .hexagon,
+            .loongarch64 => .loongarch64,
+            .m68k => .m68k,
+            .mips => .mips,
+            .mips64 => .mips64,
+            .mips64el => .mips64el,
+            .mipsel => .mipsel,
+            .msp430 => .msp430,
+            .nvptx64 => .nvptx64,
+            .powerpc => .powerpc,
+            .powerpc64 => .powerpc64,
+            .powerpc64le => .powerpc64le,
+            .riscv64 => .riscv64,
+            .s390x => .s390x,
+            .sparc => .sparc,
+            .sparc64 => .sparc64,
+            .wasm32 => .wasm32,
+            .wasm64 => .wasm64,
+            .x86 => .i686,
+            .x86_64 => .x86_64,
+
+            else => error.Unsupported,
+        };
+    }
+};
+
+pub const Vendor = enum {
+    apple,
+    esp,
+    fortanix,
+    ibm,
+    kmc,
+    linux,
+    nintendo,
+    none,
+    nvidia,
+    openwrt,
+    pc,
+    sony,
+    sun,
+    unikraft,
+    unknown,
+    uwp,
+    wrc,
+
+    pub fn fromZig(target: std.Target) error{Unsupported}!Vendor {
+        return switch (target.os.tag) {
+            .ios, .macos, .watchos, .tvos => .apple,
+            .linux => .unknown,
+            .windows => .pc,
+            .solaris => .sun,
+            .cuda => .nvidia,
+            else => {
+                if (target.abi == .android) return .linux;
+                return .unknown;
+            },
+        };
+    }
+};
+
+pub const Os = enum {
+    @"3ds",
+    aix,
+    android,
+    cuda,
+    darwin,
+    dragonfly,
+    emscripten,
+    espidf,
+    freebsd,
+    fuchsia,
+    haiku,
+    hermit,
+    hurd,
+    illumos,
+    ios,
+    l4re,
+    linux,
+    netbsd,
+    none,
+    nto,
+    openbsd,
+    psp,
+    psx,
+    redox,
+    solaris,
+    solid_asp3,
+    @"switch",
+    teeos,
+    tvos,
+    uefi,
+    unknown,
+    vita,
+    vxworks,
+    wasi,
+    watchos,
+    windows,
+    xous,
+
+    pub fn fromZig(os: std.Target.Os) error{Unsupported}!Os {
+        return switch (os.tag) {
+            .freestanding => .none,
+            .dragonfly => .dragonfly,
+            .freebsd => .freebsd,
+            .fuchsia => .fuchsia,
+            .ios => .ios,
+            .kfreebsd => .freebsd,
+            .linux => .linux,
+            .macos => .darwin,
+            .netbsd => .netbsd,
+            .openbsd => .openbsd,
+            .solaris => .solaris,
+            .uefi => .uefi,
+            .windows => .windows,
+            .haiku => .haiku,
+            .aix => .aix,
+            .cuda => .cuda,
+            .tvos => .tvos,
+            .watchos => .watchos,
+            .hermit => .hermit,
+            .hurd => .hurd,
+            .wasi => .wasi,
+            .emscripten => .emscripten,
+            .illumos => .illumos,
+            .other => .unknown,
+            else => error.Unsupported,
+        };
+    }
+};
+
+pub const Env = enum {
+    androideabi,
+    eabi,
+    eabihf,
+    elf,
+    freestanding,
+    @"gnu-atmega328",
+    gnu_ilp32,
+    gnu,
+    gnuabi64,
+    gnuabiv2,
+    gnueabi,
+    gnueabihf,
+    gnullvm,
+    gnuspe,
+    macabi,
+    msvc,
+    musl,
+    muslabi64,
+    musleabi,
+    musleabihf,
+    none,
+    ohos,
+    @"preview1-threads",
+    qnx700,
+    qnx710,
+    sgx,
+    sim,
+    softfloat,
+    spe,
+    uclibceabi,
+
+    pub fn fromZig(abi: std.Target.Abi) error{Unsupported}!Env {
+        return switch (abi) {
+            .none => .none,
+            .gnu => .gnu,
+            .gnuabi64 => .gnuabi64,
+            .gnueabi => .gnuabi64,
+            .gnueabihf => .gnueabihf,
+            .eabi => .eabi,
+            .eabihf => .eabihf,
+            .android => .androideabi,
+            .musl => .musl,
+            .musleabi => .musleabi,
+            .musleabihf => .musleabihf,
+            .msvc => .msvc,
+            .macabi => .macabi,
+            else => error.Unsupported,
+        };
+    }
+};
+
+test "tier 1" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const expectEqualStrings = std.testing.expectEqualStrings;
+
+    {
+        const target = try Target.fromArchOsAbi("aarch64-macos");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("aarch64-apple-darwin", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("aarch64-linux-gnu");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("aarch64-unknown-linux-gnu", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("aarch64-windows-msvc");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("aarch64-pc-windows-msvc", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("x86_64-macos");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("x86_64-apple-darwin", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("x86_64-linux-gnu");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("x86_64-unknown-linux-gnu", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("x86-windows-gnu");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("i686-pc-windows-gnu", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("x86-linux-gnu");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("i686-unknown-linux-gnu", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("x86_64-windows-gnu");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("x86_64-pc-windows-gnu", target_str);
+    }
+
+    {
+        const target = try Target.fromArchOsAbi("wasm32-wasi");
+        const target_str = try std.fmt.allocPrint(allocator, "{}", .{target});
+        try expectEqualStrings("wasm32-wasi", target_str);
+    }
+}


### PR DESCRIPTION
Zig doesn't have a notion of vendor in target triples making it harder to convert between Zig and Rust/LLVM. Which is especially a problem with not-as-popular or bare-metal targets. Right now only the tier 1 targets are somewhat supported.