### PR TITLE
chore: pin Rust version to 1.80.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@2a9625d550eefc3a9b1a43d342ad655f563f8241
         with:
           version: 0.13.0
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.80.1
 
       - name: Zig version
         run: zig version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,11 @@ jobs:
   ci:
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
+        platform:
+          - [ubuntu-latest, x86_64-unknown-linux-gnu]
+          - [macos-latest, aarch64-apple-darwin]
+          - [windows-latest, x86_64-pc-windows-gnu]
+    runs-on: ${{ matrix.platform[0] }}
 
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +29,8 @@ jobs:
         with:
           version: 0.13.0
       - uses: dtolnay/rust-toolchain@1.80.1
+        with:
+              targets: ${{ matrix.platform[1] }}
 
       - name: Zig version
         run: zig version

--- a/.github/workflows/cross-comp-reuse.yml
+++ b/.github/workflows/cross-comp-reuse.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: goto-bus-stop/setup-zig@2a9625d550eefc3a9b1a43d342ad655f563f8241
         with:
           version: 0.13.0
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.80.1
         with:
             targets: ${{ inputs.target-rust }}
 


### PR DESCRIPTION
1.81 fails with "error: unsupported linker arg: -exported_symbols_list"