### PR TITLE
Fixup build.zig.zon after breaking changes to zig master

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ See [`example`](./example/build.zig) for the other examples.
 
 Use `target` argument to specify the cross-compilation target:
 
-```zig// Changing this has security and trust implications.
+```zig
 const target = b.standardTargetOptions(.{});
 const build_crab = @import("build_crab");
 const crate_artifacts = build_crab.addCargoBuild(

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Cross-compilation is supported.
 
 ## Requirements
 
-* Zig >= 0.13.0
+Please see `.minimum_zig_version` field of the `build.zig.zon` file.
 
 ## Usage
 
@@ -15,7 +15,7 @@ zig fetch --save https://github.com/akarpovskii/build.crab/archive/refs/tags/v0.
 
 In `build.zig` (replace `crate` with the name of your crate):
 ```zig
-const build_crab = @import("build.crab");
+const build_crab = @import("build_crab");
 const crate_artifacts = build_crab.addCargoBuild(
     b,
     .{
@@ -43,9 +43,9 @@ See [`example`](./example/build.zig) for the other examples.
 
 Use `target` argument to specify the cross-compilation target:
 
-```zig
+```zig// Changing this has security and trust implications.
 const target = b.standardTargetOptions(.{});
-const build_crab = @import("build.crab");
+const build_crab = @import("build_crab");
 const crate_artifacts = build_crab.addCargoBuild(
     b,
     .{
@@ -78,7 +78,7 @@ So if you want to link against a Rust library that needs these intrinsics, you s
 For this purpose, `build.crab` provides an additional artifact called `strip_symbols` that repacks `.a` archive removing `.o` files containing conflicting functions (provided by the user).
 
 ```zig
-const crate_lib_path = @import("build.crab").addStripSymbols(b, .{
+const crate_lib_path = @import("build_crab").addStripSymbols(b, .{
     .name = "libcrate.a",
     .archive = b.path("path/to/libcrate.a"),
     .symbols = &.{

--- a/build.zig
+++ b/build.zig
@@ -6,7 +6,7 @@ pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("build.crab", .{
+    _ = b.addModule("build_crab", .{
         .root_source_file = b.path("src/root.zig"),
         .target = target,
         .optimize = optimize,
@@ -84,11 +84,11 @@ const CargoConfig = struct {
 /// If you need more flexibility, `build_crab` artifact can be used directly.
 /// The `args` parameter is passed to `b.dependency`.
 /// Use `args.target` to specify the target for cross-compilation.
-/// Use `args.optimize` to set the optimization level of `build.crab` binaries.
+/// Use `args.optimize` to set the optimization level of `build_crab` binaries.
 pub fn addCargoBuild(b: *std.Build, config: CargoConfig, args: anytype) std.Build.LazyPath {
     const dep_args = overrideTargetUserInput(args);
-    const @"build.crab" = b.dependency("build.crab", dep_args);
-    const build_crab = b.addRunArtifact(@"build.crab".artifact("build_crab"));
+    const build_crab_dep = b.dependency("build_crab", dep_args);
+    const build_crab = b.addRunArtifact(build_crab_dep.artifact("build_crab"));
 
     build_crab.addArg("--command");
     build_crab.addArg(config.command);
@@ -140,11 +140,11 @@ const StripSymbolsConfig = struct {
 /// If you need more flexibility, `strip_symbols` artifact can be used directly.
 /// The `args` parameter is passed to `b.dependency`.
 /// Use `args.target` to specify the target for cross-compilation.
-/// Use `args.optimize` to set the optimization level of `build.crab` binaries.
+/// Use `args.optimize` to set the optimization level of `build_crab` binaries.
 pub fn addStripSymbols(b: *std.Build, config: StripSymbolsConfig, args: anytype) std.Build.LazyPath {
     const dep_args = overrideTargetUserInput(args);
-    const @"build.crab" = b.dependency("build.crab", dep_args);
-    const strip_symbols = b.addRunArtifact(@"build.crab".artifact("strip_symbols"));
+    const build_crab = b.dependency("build_crab", dep_args);
+    const strip_symbols = b.addRunArtifact(build_crab.artifact("strip_symbols"));
 
     strip_symbols.addArg("--archive");
     strip_symbols.addFileArg(config.archive);
@@ -190,7 +190,7 @@ const StaticlibConfig = struct {
 /// Returns a path to the generated library file.
 /// The `args` parameter is passed to `b.dependency`.
 /// Use `args.target` to specify the target for cross-compilation.
-/// Use `args.optimize` to set the optimization level of `build.crab` binaries.
+/// Use `args.optimize` to set the optimization level of `build_crab` binaries.
 pub fn addRustStaticlib(b: *std.Build, config: StaticlibConfig, args: anytype) std.Build.LazyPath {
     const cargo_config: CargoConfig = .{
         .manifest_path = config.manifest_path,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,9 +1,9 @@
 .{
-    .name = "build.crab",
+    .name = .build_crab,
     .version = "0.1.7",
-
+    .fingerprint = 0x87840cb737f76c57, // Changing this has security and trust implications.
+    .minimum_zig_version = "0.14.0-dev.3445+6c3cbb0c8",
     .dependencies = .{},
-
     .paths = .{
         "build.zig",
         "build.zig.zon",

--- a/example/build.zig
+++ b/example/build.zig
@@ -29,7 +29,7 @@ pub fn addRustStaticlib(
     folder: []const u8,
     zigbuild: bool,
 ) *std.Build.Step.Run {
-    var crate_lib_path = @import("build.crab").addRustStaticlib(
+    var crate_lib_path = @import("build_crab").addRustStaticlib(
         b,
         .{
             .name = "libcrate.a",
@@ -70,7 +70,7 @@ pub fn addCargoBuild(
     target: std.Build.ResolvedTarget,
     optimize: std.builtin.OptimizeMode,
 ) *std.Build.Step.Run {
-    const artifacts = @import("build.crab").addCargoBuild(
+    const artifacts = @import("build_crab").addCargoBuild(
         b,
         .{
             .manifest_path = b.path("hello_world/Cargo.toml"),

--- a/example/build.zig.zon
+++ b/example/build.zig.zon
@@ -3,7 +3,7 @@
     .version = "0.0.0",
 
     .dependencies = .{
-        .@"build.crab" = .{
+        .build_crab = .{
             .path = "../",
         },
     },


### PR DESCRIPTION
> [!WARNING]
> THIS IS A MAJOR BREAKING CHANGE!!! Change of package name!!

There were some breaking changes to zig master recently as part of: https://github.com/ziglang/zig/issues/20178

This PR changes the name of the package, adds the new fingerprint field, and declares a new `minimum_zig_version`.

I tested this locally using:

```
zig fetch --save git+https://github.com/kj4tmp/build.crab.git#0a6552e9c117384bead1ffa6e7afb010aa1a7b35
```

And it was successfully fetched:

build.zig.zon
```zig
.build_crab = .{
    .url = "git+https://github.com/kj4tmp/build.crab.git#0a6552e9c117384bead1ffa6e7afb010aa1a7b35",
    .hash = "build_crab-0.1.7-V2z3N_aLAAAZjrTSvz0MeLHSmTwJa9w675dbGnMv3KI9",
},
```

Working on testing with real cargo project.