### PR TITLE
Use zig as the C compiler for cargo, and some other minor fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,6 +39,21 @@ pub fn build(b: *std.Build) void {
 
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_build_crab.step);
+
+    const opts = b.addOptions();
+    opts.addOption([]const u8, "zig", b.graph.zig_exe);
+    const cc = b.addExecutable(.{
+        .name = "cc",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/cc.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "build_options", .module = opts.createModule() },
+            },
+        }),
+    });
+    b.installArtifact(cc);
 }
 
 const CargoConfig = struct {
@@ -54,6 +69,9 @@ const CargoConfig = struct {
     /// Target architecture.
     /// By default, build.crab will use gnu ABI on Windows.
     rust_target: Target = .{ .override = .{} },
+
+    // Use zig itself as a cross-compiler toolchain for cargo/rust
+    use_zig_as_toolchain: bool = true,
 
     pub const Target = union(enum) {
         value: []const u8,
@@ -90,9 +108,54 @@ pub fn addCargoBuild(b: *std.Build, config: CargoConfig, args: anytype) std.Buil
     const dep_args = overrideTargetUserInput(args);
     const build_crab_dep = b.dependencyFromBuildZig(@This(), dep_args);
     const build_crab = b.addRunArtifact(build_crab_dep.artifact("build_crab"));
+    const cc = build_crab_dep.artifact("cc");
+
+    const zig_target = D: {
+        var zig_target = targetFromUserInputOptions(args);
+        if (zig_target.os.tag == .windows) {
+            zig_target.abi = .gnu;
+        }
+        break :D zig_target;
+    };
+
+    const rust_target = switch (config.rust_target) {
+        .value => |value| value,
+        .override => |value| D: {
+            const rust_target = BuildCrab.rust.Target.fromZig(zig_target) catch @panic("unable to convert target triple to Rust");
+            break :D b.fmt("{f}", .{value.override(rust_target)});
+        },
+    };
+
+    const zig_triple = zig_target.zigTriple(b.allocator) catch @panic("OOM");
+    const toolchain = b.addWriteFiles();
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), "cc");
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), "gcc");
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), "clang");
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), "ar");
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), "ranlib");
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), "dlltool");
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), b.fmt("{s}-cc", .{zig_triple}));
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), b.fmt("{s}-gcc", .{zig_triple}));
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), b.fmt("{s}-clang", .{zig_triple}));
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), b.fmt("{s}-ar", .{zig_triple}));
+    _ = toolchain.addCopyFile(cc.getEmittedBin(), b.fmt("{s}-ranlib", .{zig_triple}));
+
+    if (zig_target.os.tag == .windows) {
+        switch (zig_target.ptrBitWidth()) {
+            32 => _ = toolchain.addCopyFile(cc.getEmittedBin(), b.fmt("{t}-mingw32-dlltool", .{zig_target.cpu.arch})),
+            64 => _ = toolchain.addCopyFile(cc.getEmittedBin(), b.fmt("{t}-w64-mingw32-dlltool", .{zig_target.cpu.arch})),
+            else => @panic("unknown windows target"),
+        }
+    }
 
     build_crab.addArg("--command");
     build_crab.addArg(config.command);
+
+    if (config.use_zig_as_toolchain) {
+        build_crab.addArg("--zig-toolchain");
+        build_crab.addArg(zig_triple);
+        build_crab.addDirectoryArg(toolchain.getDirectory());
+    }
 
     build_crab.addArg("--deps");
     _ = build_crab.addDepFileOutputArg("depinfo.d");
@@ -105,23 +168,8 @@ pub fn addCargoBuild(b: *std.Build, config: CargoConfig, args: anytype) std.Buil
 
     build_crab.addArg("--");
 
-    switch (config.rust_target) {
-        .value => {
-            build_crab.addArg("--target");
-            build_crab.addArg(config.rust_target.value);
-        },
-        .override => {
-            var zig_target = targetFromUserInputOptions(args);
-            if (zig_target.os.tag == .windows) {
-                zig_target.abi = .gnu;
-            }
-            var rust_target = BuildCrab.rust.Target.fromZig(zig_target) catch @panic("unable to convert target triple to Rust");
-            rust_target = config.rust_target.override.override(rust_target);
-            build_crab.addArg("--target");
-            build_crab.addArg(b.fmt("{f}", .{rust_target}));
-        },
-    }
-
+    build_crab.addArg("--target");
+    build_crab.addArg(rust_target);
     build_crab.addArgs(config.cargo_args);
 
     return target_dir;

--- a/src/cc.zig
+++ b/src/cc.zig
@@ -1,0 +1,66 @@
+const std = @import("std");
+const opts = @import("build_options");
+
+const Tool = enum {
+    cc,
+    ar,
+    ranlib,
+    dlltool,
+};
+
+pub fn main(init: std.process.Init) !u8 {
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
+    const exe = std.fs.path.basename(args[0]);
+
+    const maybe_target: ?[]const u8, const tool: Tool = D: {
+        inline for (std.enums.values(Tool)) |tool| {
+            if (std.mem.endsWith(u8, exe, "-" ++ @tagName(tool))) {
+                break :D .{ exe[0 .. exe.len - ("-" ++ @tagName(tool)).len], tool };
+            }
+        }
+        break :D .{ null, std.meta.stringToEnum(Tool, exe) orelse .cc };
+    };
+
+    const effective_target = switch (tool) {
+        // dlltool is prefixed with {arch}-mingw32 which is not a zig target triple
+        // effective_target does not matter for that anyhow
+        .dlltool => @import("builtin").target,
+        else => try std.zig.system.resolveTargetQuery(init.io, try .parse(.{
+            .arch_os_abi = maybe_target orelse "native",
+        })),
+    };
+
+    var argv: std.ArrayList([]const u8) = .empty;
+    try argv.appendSlice(init.arena.allocator(), &.{
+        opts.zig,
+        @tagName(tool),
+    });
+
+    if (tool == .cc) {
+        if (maybe_target) |target| {
+            try argv.appendSlice(init.arena.allocator(), &.{ "-target", target });
+        }
+    }
+
+    iter: for (args[1..]) |arg| {
+        if (std.mem.startsWith(u8, arg, "--target=")) continue;
+        switch (effective_target.os.tag) {
+            .windows => {
+                const filtered: []const []const u8 = &.{
+                    "-lwindows",
+                    "-l:libpthread.a",
+                    "-lgcc",
+                    "-lmsvcrt",
+                };
+                if (std.mem.startsWith(u8, arg, "-Wl,") and std.mem.endsWith(u8, arg, "/list.def")) continue;
+                for (filtered) |filter| if (std.mem.eql(u8, arg, filter)) continue :iter;
+            },
+            else => {},
+        }
+        try argv.append(init.arena.allocator(), arg);
+    }
+
+    var child = try std.process.spawn(init.io, .{ .argv = argv.items });
+    const res = try child.wait(init.io);
+    return res.exited;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,7 @@ fn printUsage(io: std.Io) !void {
             "--target-dir <directory> " ++
             "[--deps <.d file path>] " ++
             "[--command <build (default) / rustc / zigbuild etc>] " ++
+            "[--zig-toolchain <zig target> <path to C/C++ compiler toolchain>] " ++
             "[-- <cargo <command> args>]\n",
     );
 }
@@ -29,6 +30,9 @@ pub fn main(init: std.process.Init) !void {
     const allocator = init.gpa;
 
     var command: ?[]const u8 = null;
+    var rust_target: ?[]const u8 = null;
+    var zig_target: ?[]const u8 = null;
+    var zig_toolchain: ?[]const u8 = null;
     var deps_file: ?[]const u8 = null;
     var target_dir: ?[]const u8 = null;
     var manifest_path: ?[]const u8 = null;
@@ -42,6 +46,10 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--command")) {
             command = args.next() orelse break;
         }
+        if (std.mem.eql(u8, arg, "--zig-toolchain")) {
+            zig_target = args.next() orelse break;
+            zig_toolchain = args.next() orelse break;
+        }
         if (std.mem.eql(u8, arg, "--target-dir")) {
             target_dir = args.next() orelse break;
         }
@@ -54,12 +62,18 @@ pub fn main(init: std.process.Init) !void {
         if (std.mem.eql(u8, arg, "--")) {
             while (args.next()) |cargo_arg| {
                 try cargo_args.append(allocator, cargo_arg);
+                if (std.mem.eql(u8, cargo_arg, "--target")) {
+                    rust_target = args.next() orelse break;
+                    try cargo_args.append(allocator, rust_target.?);
+                }
             }
             break;
         }
     }
 
     std.log.debug("Received:", .{});
+    std.log.debug("rust-target = {?s}", .{rust_target});
+    std.log.debug("zig-toolchain = {?s} {?s}", .{ zig_target, zig_toolchain });
     std.log.debug("target-dir = {?s}", .{target_dir});
     std.log.debug("manifest-path = {?s}", .{manifest_path});
     std.log.debug("deps = {?s}", .{deps_file});
@@ -86,9 +100,31 @@ pub fn main(init: std.process.Init) !void {
         try cargo_cmd.append(allocator, arg);
     }
 
+    var allocating: std.Io.Writer.Allocating = .init(init.arena.allocator());
+    defer allocating.deinit();
+    var env = init.environ_map;
+    if (zig_toolchain) |toolchain_path| {
+        try allocating.writer.writeAll(toolchain_path);
+        if (env.get("PATH")) |path| {
+            try allocating.writer.writeByte(':');
+            try allocating.writer.writeAll(path);
+        }
+        try env.put("PATH", try allocating.toOwnedSlice());
+        if (rust_target) |cargo_target| {
+            try allocating.writer.writeAll("CARGO_TARGET_");
+            for (cargo_target) |c| switch (c) {
+                '-' => try allocating.writer.writeByte('_'),
+                else => try allocating.writer.writeByte(std.ascii.toUpper(c)),
+            };
+            try allocating.writer.writeAll("_LINKER");
+            try env.put(try allocating.toOwnedSlice(), try std.fmt.allocPrint(init.arena.allocator(), "{s}-cc", .{zig_target.?}));
+        }
+    }
+
     std.log.debug("about to execute {f}", .{std.json.fmt(cargo_cmd.items, .{})});
     const cargo_result = std.process.run(allocator, io, .{
         .argv = cargo_cmd.items,
+        .environ_map = env,
     }) catch |err| switch (err) {
         error.FileNotFound => {
             std.log.err("cargo is not installed", .{});

--- a/src/rust.zig
+++ b/src/rust.zig
@@ -385,7 +385,10 @@ pub const Env = union(enum) {
             .androideabi => .androideabi,
             .musl => .musl,
             .muslabi64 => .muslabi64,
-            .musleabi => .musleabi,
+            .musleabi => switch (target.cpu.arch) {
+                .mipsel => .musl,
+                else => .musleabi,
+            },
             .musleabihf => .musleabihf,
             .msvc => .msvc,
             .ohos => .ohos,

--- a/tests/build.zig
+++ b/tests/build.zig
@@ -1,0 +1,36 @@
+const std = @import("std");
+const build_crab = @import("build_crab");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const zigbuild_dep = b.dependency("zigbuild", .{});
+
+    const zigbuild_tests: []const []const u8 = &.{
+        // test depends on env: tries to search FHS /
+        // "bindgen-exhaustive",
+        "hello-aws-lc-rs",
+        // requires cmake
+        "hello-cmake",
+        "hello-rustls",
+        // needs gnumake
+        "hello-tls",
+        // this test seems broken upstream
+        // "hello-windows",
+        "libhello",
+        "target-cpu",
+    };
+
+    for (zigbuild_tests) |case| {
+        const cargo = build_crab.addCargoBuild(b, .{
+            .manifest_path = zigbuild_dep.path(b.pathJoin(&.{ "tests", case, "Cargo.toml" })),
+            .cargo_args = &.{"--quiet"},
+        }, .{
+            .optimize = optimize,
+            .target = target,
+        });
+        const install = b.addInstallDirectory(.{ .source_dir = cargo, .install_dir = .prefix, .install_subdir = "install" });
+        b.default_step.dependOn(&install.step);
+    }
+}

--- a/tests/build.zig.zon
+++ b/tests/build.zig.zon
@@ -1,0 +1,18 @@
+.{
+    .name = .tests,
+    .version = "0.0.0",
+    .fingerprint = 0x1260fc5e5b170b5c,
+
+    .dependencies = .{
+        .build_crab = .{
+            .path = "../",
+        },
+        .zigbuild = .{
+            .url = "git+https://github.com/rust-cross/cargo-zigbuild.git#cd38ab2c56dfb70bc7459dd007d8cc5d8aec94ad",
+            .hash = "N-V-__8AAPDvBgCl6usLjcu9erAV63uW-6J-f8uClaZo_VJ4",
+        },
+    },
+    .paths = .{
+        "",
+    },
+}


### PR DESCRIPTION
This uses the existing zig installation as C compiler for cargo. I did not test this extensively, and I wonder if there should still be option to not pass zig as CC for some niche cases where person really wants another C compiler?