### PR TITLE
Minor fixes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -88,7 +88,7 @@ const CargoConfig = struct {
 /// Use `args.optimize` to set the optimization level of `build_crab` binaries.
 pub fn addCargoBuild(b: *std.Build, config: CargoConfig, args: anytype) std.Build.LazyPath {
     const dep_args = overrideTargetUserInput(args);
-    const build_crab_dep = b.dependency("build_crab", dep_args);
+    const build_crab_dep = b.dependencyFromBuildZig(@This(), dep_args);
     const build_crab = b.addRunArtifact(build_crab_dep.artifact("build_crab"));
 
     build_crab.addArg("--command");

--- a/src/main.zig
+++ b/src/main.zig
@@ -87,9 +87,15 @@ pub fn main(init: std.process.Init) !void {
     }
 
     std.log.debug("about to execute {f}", .{std.json.fmt(cargo_cmd.items, .{})});
-    const cargo_result = try std.process.run(allocator, io, .{
+    const cargo_result = std.process.run(allocator, io, .{
         .argv = cargo_cmd.items,
-    });
+    }) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.log.err("cargo is not installed", .{});
+            return err;
+        },
+        else => return err,
+    };
     defer {
         allocator.free(cargo_result.stdout);
         allocator.free(cargo_result.stderr);


### PR DESCRIPTION
This lets you use build.crab without hardcoding the dependency name in build.zig.zon to `build_crab`. It also adds nicer error message when cargo is not found in the PATH.